### PR TITLE
Add global image fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AjaxInWP Brass-Metal is a fully styled WordPress theme designed to provide a ric
 - **Multiple Block Templates**: Templates for posts, pages, archives, and 404 screens.
 - **Block Patterns**: Reusable layout patterns registered via PHP.
 - **Local Assets**: Bootstrap and Font Awesome are bundled locally for privacy.
+- **Image Fallbacks**: Missing images automatically display a default placeholder.
 - **Flexible Navigation**: Multiple menu locations and customizable fonts.
 - **Automatic Table of Contents**: Posts include a generated index for easy navigation.
 - **OOP Architecture**: Core features are encapsulated in the `AjaxinWP_Theme` class for cleaner code.

--- a/assets/js/image-fallback.js
+++ b/assets/js/image-fallback.js
@@ -1,0 +1,9 @@
+(function(){
+    document.addEventListener('error', function(event){
+        var target = event.target;
+        if(target.tagName === 'IMG' && !target.dataset.fallbackLoaded){
+            target.dataset.fallbackLoaded = 'true';
+            target.src = ajaxinwp_params.fallbackImage;
+        }
+    }, true);
+})();

--- a/functions.php
+++ b/functions.php
@@ -65,6 +65,7 @@ function ajaxinwp_styles_and_scripts() {
     wp_enqueue_script('jquery');
     wp_enqueue_script('bootstrap-js', get_template_directory_uri() . '/assets/js/bootstrap.bundle.min.js', array('jquery'), filemtime(get_template_directory() . '/assets/js/bootstrap.bundle.min.js'), true);
     wp_enqueue_script('ajaxinwp-js', get_template_directory_uri() . '/assets/js/ajaxinwp.js', array('jquery'), wp_get_theme()->get('Version'), true);
+    wp_enqueue_script('ajaxinwp-image-fallback', get_template_directory_uri() . '/assets/js/image-fallback.js', array('ajaxinwp-js'), wp_get_theme()->get('Version'), true);
     wp_enqueue_script('custom-logo-script', get_template_directory_uri() . '/assets/js/logo.js', [], wp_get_theme()->get('Version'), true);
 
     // Localize script
@@ -72,7 +73,8 @@ function ajaxinwp_styles_and_scripts() {
         'ajax_url' => admin_url('admin-ajax.php'),
         'nonce'    => wp_create_nonce('ajaxinwp_nonce'),
         'homeURL'  => get_home_url(),
-        'isHome'   => is_home() || is_front_page()
+        'isHome'   => is_home() || is_front_page(),
+        'fallbackImage' => get_template_directory_uri() . '/assets/img/fallback1080x720.jpg'
     ));
 
     // Add inline script


### PR DESCRIPTION
## Summary
- add JavaScript to replace missing images with a fallback
- wire up new script and pass fallback URL via `ajaxinwp_params`
- document automatic image fallbacks

## Testing
- `php -l functions.php`

------
https://chatgpt.com/codex/tasks/task_e_68503f66ba288324a27e991bf921a130