### PR TITLE
Enhance archive layouts and TOC handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ AjaxInWP Brass-Metal is a fully styled WordPress theme designed to provide a ric
 
 
 - **Flexible Navigation**: Multiple menu locations and new offcanvas or navbar menu styles.
-- **Automatic Table of Contents**: Posts include a generated index for easy navigation.
+- **Automatic Table of Contents**: Posts and pages include a generated table of contents linking to headings for easy navigation.
 - **OOP Architecture**: Core features are encapsulated in the `AjaxinWP_Theme` class for cleaner code.
 ## Why Ajax?
 
@@ -121,7 +121,7 @@ Premium block patterns help you build pages faster. All patterns are registered 
 Insert any of these patterns from the block inserter to quickly compose rich layouts.
 
 ## Table of Contents
-Each post automatically displays a table of contents based on its headings. This helps readers navigate long articles more easily.
+Each article automatically displays a table of contents based on its headings. This helps readers navigate long articles more easily.
 
  
 

--- a/functions.php
+++ b/functions.php
@@ -3,63 +3,32 @@
 /**
  * Get post thumbnail or fallback image.
  */
-function get_post_thumbnail_or_fallback($post_id, $size = 'medium', $attr = '') {
-    if ( ! get_theme_mod('ajaxinwp_show_featured', true) ) {
+function get_post_thumbnail_or_fallback( $post_id, $size = 'medium', $attr = '' ) {
+    if ( ! get_theme_mod( 'ajaxinwp_show_featured', true ) ) {
         return '';
     }
-    if (has_post_thumbnail($post_id)) {
-        return get_the_post_thumbnail($post_id, $size, $attr);
+
+    if ( has_post_thumbnail( $post_id ) ) {
+        return get_the_post_thumbnail( $post_id, $size, $attr );
     }
 
-    $fallback = get_theme_mod('ajaxinwp_fallback_image');
-    if (!$fallback) {
+    $fallback = get_theme_mod( 'ajaxinwp_fallback_image' );
+    if ( ! $fallback ) {
         $fallback = get_template_directory_uri() . '/assets/img/fallback1080x720.jpg';
     }
 
-    return '<img src="' . esc_url($fallback) . '" alt="' . esc_attr__('Default Image', 'ajaxinwp') . '" class="attachment-' . esc_attr($size) . ' size-' . esc_attr($size) . ' wp-post-image">';
+    return '<img src="' . esc_url( $fallback ) . '" alt="' . esc_attr__( 'Default Image', 'ajaxinwp' ) . '" class="attachment-' . esc_attr( $size ) . ' size-' . esc_attr( $size ) . ' wp-post-image">';
 }
 
-
- 
-
-// Load helper files
+// Load helper files.
 require_once get_template_directory() . '/helpers/bootstrap-menu-walker.php';
 require_once get_template_directory() . '/helpers/bootstrap-comment-walker.php';
- 
 
-// Load OOP modules
+// Load OOP modules.
 require_once get_template_directory() . '/inc/class-ajaxinwp-theme.php';
 require_once get_template_directory() . '/inc/class-ajaxinwp-customizer.php';
 require_once get_template_directory() . '/inc/class-ajaxinwp-css-generator.php';
 require_once get_template_directory() . '/inc/class-ajaxinwp-widgets.php';
-
-AjaxinWP_Theme::get_instance();
-AjaxinWP_Customizer::init();
-AjaxinWP_CSS_Generator::init();
-AjaxinWP_Widgets::init();
-
-
- 
-
-// Load OOP modules
-require_once get_template_directory() . '/inc/class-ajaxinwp-theme.php';
-require_once get_template_directory() . '/inc/class-ajaxinwp-customizer.php';
-require_once get_template_directory() . '/inc/class-ajaxinwp-css-generator.php';
-require_once get_template_directory() . '/inc/class-ajaxinwp-widgets.php';
-
-AjaxinWP_Theme::get_instance();
-AjaxinWP_Customizer::init();
-AjaxinWP_CSS_Generator::init();
-AjaxinWP_Widgets::init();
-
-
-
-// Load OOP modules
-require_once get_template_directory() . '/inc/class-ajaxinwp-theme.php';
-require_once get_template_directory() . '/inc/class-ajaxinwp-customizer.php';
-require_once get_template_directory() . '/inc/class-ajaxinwp-css-generator.php';
-require_once get_template_directory() . '/inc/class-ajaxinwp-widgets.php';
- 
 
 AjaxinWP_Theme::get_instance();
 AjaxinWP_Customizer::init();
@@ -78,52 +47,28 @@ if ( ! function_exists( 'is_ajax_request' ) ) {
     }
 }
 
-
-
-AjaxinWP_Theme::get_instance();
-AjaxinWP_Customizer::init();
-AjaxinWP_CSS_Generator::init();
-AjaxinWP_Widgets::init();
- 
-
- 
- 
-if ( ! function_exists( 'is_ajax_request' ) ) {
-    /**
-     * Check if the current request is an AJAX call.
-     *
-     * @return bool True when the request is via XHR.
-     */
-    function is_ajax_request() {
-        return isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) &&
-            strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) === 'xmlhttprequest';
-    }
-}
-
- 
-
- 
 /**
  * Print HTML with meta information for the current post-date/time.
  */
-if (!function_exists('ajaxinwp_posted_on')) :
+if ( ! function_exists( 'ajaxinwp_posted_on' ) ) :
     function ajaxinwp_posted_on() {
         $time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-        
-        if (get_the_time('U') !== get_the_modified_time('U')) {
+
+        if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
             $time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
         }
 
-        $time_string = sprintf($time_string,
-            esc_attr(get_the_date(DATE_W3C)),
-            esc_html(get_the_date()),
-            esc_attr(get_the_modified_date(DATE_W3C)),
-            esc_html(get_the_modified_date())
+        $time_string = sprintf(
+            $time_string,
+            esc_attr( get_the_date( DATE_W3C ) ),
+            esc_html( get_the_date() ),
+            esc_attr( get_the_modified_date( DATE_W3C ) ),
+            esc_html( get_the_modified_date() )
         );
 
         $posted_on = sprintf(
-            esc_html_x('Posted on %s', 'post date', 'ajaxinwp'),
-            '<a href="' . esc_url(get_permalink()) . '" rel="bookmark">' . $time_string . '</a>'
+            esc_html_x( 'Posted on %s', 'post date', 'ajaxinwp' ),
+            '<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
         );
 
         echo '<span class="posted-on">' . $posted_on . '</span>';
@@ -133,11 +78,11 @@ endif;
 /**
  * Print HTML with meta information for the current post author.
  */
-if (!function_exists('ajaxinwp_posted_by')) :
+if ( ! function_exists( 'ajaxinwp_posted_by' ) ) :
     function ajaxinwp_posted_by() {
         $byline = sprintf(
-            esc_html_x('by %s', 'post author', 'ajaxinwp'),
-            '<span class="author vcard"><a class="url fn n" href="' . esc_url(get_author_posts_url(get_the_author_meta('ID'))) . '">' . esc_html(get_the_author()) . '</a></span>'
+            esc_html_x( 'by %s', 'post author', 'ajaxinwp' ),
+            '<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
         );
 
         echo '<span class="byline"> ' . $byline . '</span>';
@@ -147,27 +92,27 @@ endif;
 /**
  * Print HTML with meta information for the categories, tags and comments.
  */
-if (!function_exists('ajaxinwp_entry_footer')) :
+if ( ! function_exists( 'ajaxinwp_entry_footer' ) ) :
     function ajaxinwp_entry_footer() {
-        if ('post' === get_post_type()) {
-            $categories_list = get_the_category_list(esc_html__(', ', 'ajaxinwp'));
-            if ($categories_list) {
-                printf('<span class="cat-links">' . esc_html__('Posted in %1$s', 'ajaxinwp') . '</span> | ', $categories_list);
+        if ( 'post' === get_post_type() ) {
+            $categories_list = get_the_category_list( esc_html__( ', ', 'ajaxinwp' ) );
+            if ( $categories_list ) {
+                printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'ajaxinwp' ) . '</span> | ', $categories_list );
             }
 
-            $tags_list = get_the_tag_list('', esc_html__(', ', 'ajaxinwp'));
-            if ($tags_list) {
-                printf('<span class="tags-links">' . esc_html__('Tagged %1$s', 'ajaxinwp') . '</span>', $tags_list);
+            $tags_list = get_the_tag_list( '', esc_html__( ', ', 'ajaxinwp' ) );
+            if ( $tags_list ) {
+                printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'ajaxinwp' ) . '</span>', $tags_list );
             }
         }
 
-        if (!is_single() && !post_password_required() && (comments_open() || get_comments_number())) {
+        if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
             echo '<span class="comments-link">';
             comments_popup_link(
                 sprintf(
                     wp_kses(
-                        __('Leave a Comment<span class="screen-reader-text"> on %s</span>', 'ajaxinwp'),
-                        array('span' => array('class' => array()))
+                        __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'ajaxinwp' ),
+                        array( 'span' => array( 'class' => array() ) )
                     ),
                     get_the_title()
                 )
@@ -178,8 +123,8 @@ if (!function_exists('ajaxinwp_entry_footer')) :
         edit_post_link(
             sprintf(
                 wp_kses(
-                    __('Edit <span class="screen-reader-text">%s</span>', 'ajaxinwp'),
-                    array('span' => array('class' => array()))
+                    __( 'Edit <span class="screen-reader-text">%s</span>', 'ajaxinwp' ),
+                    array( 'span' => array( 'class' => array() ) )
                 ),
                 get_the_title()
             ),
@@ -189,5 +134,3 @@ if (!function_exists('ajaxinwp_entry_footer')) :
     }
 endif;
 
-
- 

--- a/inc/ajax-redirect.php
+++ b/inc/ajax-redirect.php
@@ -47,7 +47,9 @@ add_action('wp_enqueue_scripts', function() {
 });
 
 // Check if it's an AJAX request
-function is_ajax_request() {
-    return isset($_SERVER['HTTP_X_REQUESTED_WITH']) && strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
+if ( ! function_exists( 'is_ajax_request' ) ) {
+    function is_ajax_request() {
+        return isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) === 'xmlhttprequest';
+    }
 }
 ?>

--- a/inc/class-ajaxinwp-theme.php
+++ b/inc/class-ajaxinwp-theme.php
@@ -171,11 +171,11 @@ class AjaxinWP_Theme {
 
     /** Add a table of contents to post content */
     public function add_table_of_contents( $content ) {
-        if ( is_singular( 'post' ) && in_the_loop() && is_main_query() ) {
+        if ( is_singular() && in_the_loop() && is_main_query() ) {
             if ( preg_match_all( '/<h([2-3])[^>]*>(.*?)<\/h\1>/', $content, $matches ) ) {
                 $toc = '<nav class="ajaxinwp-toc"><strong>' . esc_html__( 'Contents', 'ajaxinwp' ) . '</strong><ol>';
                 foreach ( $matches[2] as $index => $heading ) {
-                    $slug    = 'toc-' . ( $index + 1 );
+                    $slug    = sanitize_title( wp_strip_all_tags( $heading ) );
                     $content = str_replace( $matches[0][ $index ], '<h' . $matches[1][ $index ] . ' id="' . esc_attr( $slug ) . '">' . $heading . '</h' . $matches[1][ $index ] . '>', $content );
                     $toc    .= '<li><a href="#' . esc_attr( $slug ) . '">' . wp_strip_all_tags( $heading ) . '</a></li>';
                 }
@@ -183,6 +183,7 @@ class AjaxinWP_Theme {
                 return $toc . $content;
             }
         }
+
         return $content;
     }
 

--- a/partials/partials-content-archive.php
+++ b/partials/partials-content-archive.php
@@ -13,6 +13,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
     <header class="entry-header">
+        <div class="post-thumbnail">
+            <a href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
+                <?php echo get_post_thumbnail_or_fallback( get_the_ID(), 'medium' ); ?>
+            </a>
+            <div class="date-card">
+                <time class="entry-date published updated" datetime="<?php echo esc_attr( get_the_date( 'c' ) ); ?>">
+                    <span class="day"><?php echo esc_html( get_the_date( 'd' ) ); ?></span>
+                    <span class="month"><?php echo esc_html( get_the_date( 'M' ) ); ?></span>
+                    <span class="year"><?php echo esc_html( get_the_date( 'y' ) ); ?></span>
+                </time>
+            </div>
+        </div>
         <?php
         if ( is_singular() ) :
             the_title( '<h1 class="entry-title">', '</h1>' );

--- a/partials/partials-content-category.php
+++ b/partials/partials-content-category.php
@@ -35,6 +35,10 @@
                         <h2 id="post-title-<?php the_ID(); ?>" class="entry-title">
                             <a href="<?php echo esc_url(get_permalink()); ?>" rel="bookmark"><?php the_title(); ?></a>
                         </h2>
+                        <div class="entry-meta">
+                            <?php ajaxinwp_posted_on(); ?>
+                            <?php ajaxinwp_posted_by(); ?>
+                        </div>
                         <div class="entry-meta  card-img-overlay">
                             <div class="date-card">
                                 <time class="entry-date published updated" datetime="<?php echo esc_attr(get_the_date('c')); ?>">

--- a/partials/partials-content-home.php
+++ b/partials/partials-content-home.php
@@ -44,6 +44,10 @@
                         <h2 id="post-title-<?php the_ID(); ?>" class="entry-title">
                             <a href="<?php echo esc_url(get_permalink()); ?>" rel="bookmark"><?php the_title(); ?></a>
                         </h2>
+                        <div class="entry-meta">
+                            <?php ajaxinwp_posted_on(); ?>
+                            <?php ajaxinwp_posted_by(); ?>
+                        </div>
                     </header><!-- .entry-header -->
 
                     <div class="entry-content">


### PR DESCRIPTION
## Summary
- sanitize TOC anchor slugs and allow on pages
- show featured thumbnails on archive posts
- display author/date meta on home and archive cards
- update docs about the table of contents

## Testing
- `grep -R "<<<<<<" -n --exclude=screenshot.png`
- `php -l inc/class-ajaxinwp-theme.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a5a666248324b70f788bcd828e5b